### PR TITLE
Provide caps lock option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A simple browser extension to improve the NY Times Crossword
 
 * **Pencil shift:** Hold shift to use pencil temporarily, double tap to switch.
 
+    - **Optionally:** Use Caps Lock instead of double tap to switch pencil
+
 * **Pause shortcut:** Use Alt-P (or Option-P) to pause/unpause the game.
 
 * **Dark mode (optional):** The dark mode preserves highlight colors and keeps shaded

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -5,6 +5,10 @@ Enhancements:
 * Alt-P pauses/unpauses the timer
   (...).
 
+* Provide an option to use Caps Lock instead of double-tapping shift, as a way of
+  switching to pencil mode
+  (...).
+
 ## 1.1 (221116)
 
 Bug Fixes:

--- a/src/betternytc.js
+++ b/src/betternytc.js
@@ -1,9 +1,15 @@
 const BETTER_NYTC_DATA = {
   darkMode: false,
   redPencil: false,
+  useCapsLock: false,
   controlPencilWithShift: true,
   shiftCounter: 0,
   shiftTimeout: null,
+  /* When the page loads, we don't know if caps lock is initially active or not.
+   * In all browsers, we can find out when the user first types a letter, without holding shift.
+   * In Chrome, we also find out as soon as caps lock is pressed (since keyup/keydown disambiguates).
+   */
+  weThinkCapsLockIsActive: false,
 };
 
 const SELECTORS = {
@@ -11,6 +17,8 @@ const SELECTORS = {
   continueButton: '.pz-moment__button',
   cPanelSecondCol: 'div.xwd__settings-modal--column:nth-child(2)',
   pencilButtonAnyState: '.xwd__toolbar_icon--pencil, .xwd__toolbar_icon--pencil-active',
+  pencilButtonActive: '.xwd__toolbar_icon--pencil-active',
+  pencilButtonInactive: '.xwd__toolbar_icon--pencil',
   puzzleRoot: '#pz-game-root',
   modalZone: '#portal-game-modals',
   settingsPanel: '#settings-panel',
@@ -20,6 +28,7 @@ function storeSettings() {
   const keys = {
     darkMode: BETTER_NYTC_DATA.darkMode,
     redPencil: BETTER_NYTC_DATA.redPencil,
+    useCapsLock: BETTER_NYTC_DATA.useCapsLock,
   };
   return chrome ?
       new Promise(resolve => chrome.storage.local.set(keys, resolve)) :
@@ -30,6 +39,7 @@ function loadSettings() {
   const keys = {
     darkMode: false,
     redPencil: false,
+    useCapsLock: false,
   };
   return chrome ?
       new Promise(resolve => chrome.storage.local.get(keys, resolve)) :
@@ -120,12 +130,80 @@ function addControlsSection(column) {
     text: 'Red pencil',
     onclick: event => { setRedPencil(event.target.checked); },
   }));
+  inset.appendChild(makeControlsCheckbox({
+    name: 'betterNytcUseCapsLock',
+    checked: BETTER_NYTC_DATA.useCapsLock,
+    text: 'Caps Lock activates pencil',
+    onclick: event => { setUseCapsLock(event.target.checked); },
+  }));
   column.appendChild(section);
 }
 
-/* Key handler that achieves the activation of pencil mode via the shift key.
+// Whatever state the pencil is in, flip it.
+function togglePencil() {
+  const icon = document.querySelector(SELECTORS.pencilButtonAnyState);
+  icon.click();
+}
+
+// Make pencil mode active.
+function activatePencil() {
+  const icon = document.querySelector(SELECTORS.pencilButtonInactive);
+  if (icon) {
+    icon.click();
+  }
+}
+
+// Make pencil mode inactive.
+function deactivatePencil() {
+  const icon = document.querySelector(SELECTORS.pencilButtonActive);
+  if (icon) {
+    icon.click();
+  }
+}
+
+// Flip our internal rep of whether caps lock is active
+function toggleInternalCapsLock() {
+  BETTER_NYTC_DATA.weThinkCapsLockIsActive = !BETTER_NYTC_DATA.weThinkCapsLockIsActive;
+  syncPencilWithCapsLock();
+}
+
+// Internally mark caps lock as active.
+function activateInternalCapsLock() {
+  BETTER_NYTC_DATA.weThinkCapsLockIsActive = true;
+  syncPencilWithCapsLock();
+}
+
+// Internally mark caps lock as inactive.
+function deactivateInternalCapsLock() {
+  BETTER_NYTC_DATA.weThinkCapsLockIsActive = false;
+  syncPencilWithCapsLock();
+}
+
+// IF we're set to use caps lock to control pencil, then put them in sync.
+function syncPencilWithCapsLock() {
+  if (BETTER_NYTC_DATA.useCapsLock) {
+    if (BETTER_NYTC_DATA.weThinkCapsLockIsActive) {
+      activatePencil();
+    } else {
+      deactivatePencil();
+    }
+  }
+}
+
+// Pass a key event. We return true if this event shows that caps lock is active.
+function eventShowsActualCapsLock(e) {
+  const k = e.key;
+  return k === k.toUpperCase() && k !== k.toLowerCase() && !e.shiftKey;
+}
+
+/* Key handler for events taking place in the puzzle area.
  */
-function handleKeyEvent(e) {
+function puzzleAreaKeyEvent(e) {
+  // Detect actual caps lock:
+  if (eventShowsActualCapsLock(e)) {
+    activateInternalCapsLock();
+  }
+  // Control pencil with shift:
   if (BETTER_NYTC_DATA.controlPencilWithShift && e.key === "Shift") {
     // We count all key-downs and key-ups of the shift key, but reset the counter if
     // no signal for 160ms. This means a double-tap achieved within 640ms raises the
@@ -139,10 +217,43 @@ function handleKeyEvent(e) {
     // This means holding shift achieves a temporary toggle.
     // But if the counter reaches 4, the first 3 toggles go through and the 4th is ignored.
     // The net effect is that the writing tool is switched and stays switched.
-    if (BETTER_NYTC_DATA.shiftCounter < 4) {
-      const icon = document.querySelector(SELECTORS.pencilButtonAnyState);
-      icon.click();
+    // Alternatively, if the user wants caps lock (instead of double-shift) to be what
+    // toggles permanent pencil mode, then we disregard the counter here.
+    if (BETTER_NYTC_DATA.useCapsLock || BETTER_NYTC_DATA.shiftCounter < 4) {
+      togglePencil();
     }
+  }
+}
+
+function docKeyDown(e) {
+  // Pause/Unpause on Alt-P
+  if (e.code === "KeyP" && e.altKey) {
+    const continueButton = getContinueButton();
+    if (continueButton) {
+      continueButton.click();
+    } else {
+      document.querySelector(SELECTORS.pauseButton).click();
+    }
+  }
+  // Caps lock
+  if (e.code === "CapsLock") {
+    /* Chrome has the nice feature that when caps lock is activated, there is
+     * only a keydown event (no keyup), while on deactivation it is the opposite,
+     * i.e. only a keyup (no keydown). It is essentially like one long keypress.
+     * Unfortunately, this is not the case in Firefox. There, both presses simply
+     * result in a keydown event.
+     */
+    if (window.chrome) {
+      activateInternalCapsLock();
+    } else {
+      toggleInternalCapsLock();
+    }
+  }
+}
+
+function docKeyUp(e) {
+  if (window.chrome && e.code === "CapsLock") {
+    deactivateInternalCapsLock();
   }
 }
 
@@ -172,26 +283,22 @@ function setRedPencil(b) {
   storeSettings();
 }
 
+/* Set control via caps lock, and also record the setting.
+ */
+function setUseCapsLock(b) {
+  BETTER_NYTC_DATA.useCapsLock = b;
+  storeSettings();
+  syncPencilWithCapsLock();
+}
+
 function getContinueButton() {
   return document.querySelector(SELECTORS.continueButton);
 }
 
-function docKeyDown(e) {
-  // Pause/Unpause on Alt-P
-  if (e.code === "KeyP" && e.altKey) {
-    const continueButton = getContinueButton();
-    if (continueButton) {
-      continueButton.click();
-    } else {
-      document.querySelector(SELECTORS.pauseButton).click();
-    }
-  }
-}
-
-
 async function startup() {
   // Global key listeners
   document.addEventListener('keydown', docKeyDown);
+  document.addEventListener('keyup', docKeyUp);
 
   // Tool tip "Alt-P" for pause/unpause.
   // Seem to need a delay in Firefox (but not in Chrome).
@@ -202,8 +309,8 @@ async function startup() {
 
   // Set up key listening so that shift key controls pencil mode.
   const board = document.querySelector(SELECTORS.puzzleRoot);
-  board.addEventListener('keydown', handleKeyEvent);
-  board.addEventListener('keyup', handleKeyEvent);
+  board.addEventListener('keydown', puzzleAreaKeyEvent);
+  board.addEventListener('keyup', puzzleAreaKeyEvent);
 
   // Watch for the control panel modal. It is regenerated each time the user goes into
   // settings, so we need to add our controls each time.
@@ -221,6 +328,7 @@ async function startup() {
   const settings = await loadSettings();
   setDarkMode(settings.darkMode);
   setRedPencil(settings.redPencil);
+  setUseCapsLock(settings.useCapsLock);
 }
 
 startup();


### PR DESCRIPTION
Resolves #3 

If the user chooses it (new option in config panel), then caps lock can be used as an alternative to double-tapping shift.