### PR TITLE
Make caps lock handling more responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3 (------)
+
+Enhancements:
+
+* Make caps lock handling more responsive
+
 ## 1.2 (230225)
 
 Enhancements:


### PR DESCRIPTION
We use `event.getModifierState()` to detect caps lock's actual activation state, on any key event, and in both Chrome and Firefox, on both macOS and Windows.

We still don't know the initial state on page load, but as soon as any key has been pressed, theoretically we now know, and respond accordingly.